### PR TITLE
Fix settings binding

### DIFF
--- a/OctoPrint_MeatPack/__init__.py
+++ b/OctoPrint_MeatPack/__init__.py
@@ -78,7 +78,7 @@ class MeatPackPlugin(
 
     def get_template_configs(self):
         return [
-            dict(type="settings")
+            dict(type="settings", custom_bindings=False)
         ]
 
     def get_version(self):


### PR DESCRIPTION
Not tested it, but that should work. I've written enough plugins that at some point I hope I will be able to spot problems without needing to experiment first. Who knows. Anyway, off topic, you didn't care about that.

Your settings binding was using `settings.settings.plugins.xxx.xxx`, however this is only available in the settingsViewModel. This view model is applied to all components in the settings dialog *except* those that are configured with custom bindings as False. This is the default, to disable it you need to set this as I have done.

on_settings_save is only called when there is a change in the plugin's settings, so when the binding does not work there is no changes, hence it is never saved.