### PR TITLE
Cleanup of js UI and settings

### DIFF
--- a/OctoPrint_MeatPack/__init__.py
+++ b/OctoPrint_MeatPack/__init__.py
@@ -89,7 +89,8 @@ class MeatPackPlugin(
             enableMeatPack=True,
             logTransmissionStats=True,
             playSongOnPrintComplete=False,
-            omitSpaces=True
+            omitSpaces=True,
+            logTransmissionStatsType='state'
         )
 
 # -------------------------------------------------------------------------------

--- a/OctoPrint_MeatPack/static/js/meatpack.js
+++ b/OctoPrint_MeatPack/static/js/meatpack.js
@@ -10,6 +10,12 @@ $(function() {
     function MeatPackViewModel(parameters) {
         var self = this;
 
+        self.settings = parameters[0];
+        self.printerConn = parameters[1];
+
+        // Locales strings
+        var containerTitle = "Meatpack statistics";
+
         var name_total = gettext("Effective TX");
         var text_total = gettext("Total transmitted data for lifetime of connection.");
 
@@ -25,10 +31,10 @@ $(function() {
         var name_enabled = gettext("Packing State");
         var text_enabled = gettext("State of whether or not g-code packing is enabled.");
 
+        var txt_no_data = gettext("No data");
 
-        self.printerState = parameters[0];
-        self.settings = parameters[1];
-        self.printerConn = parameters[2];
+        var txt_lbl_disabled = gettext("Disabled");
+        var txt_lbl_enabled = gettext("Disabled");
 
         self.transmissionStats = ko.observableArray([]);
         self.dataReceived = false;
@@ -36,35 +42,43 @@ $(function() {
         self.totalBytesSec = 0.0
         self.packedBytes = 0.0
 
+        // Settings lookup shortcuts
         self.packingEnabled = ko.pureComputed(function() {
             return self.settings.settings.plugins.meatpack.enableMeatPack() ? true : false;
         });
 
-        self.allVisible = ko.pureComputed(function() {
+        self.showStatsInUI = ko.pureComputed(function() {
             return self.settings.settings.plugins.meatpack.logTransmissionStats() ? true : false;
         });
 
-        self.showTXStats = ko.pureComputed(function() {
-            // #TESTING
-            return true;
+        self.windowType = function() {
+            return self.settings.settings.plugins.meatpack.logTransmissionStatsType();
+        };
 
+
+        // Should we show the data based on printer operational status
+        self.showTXStats = function() {
             if (self.printerConn.isOperational()) return true;
             return false;
-        });
-
-        self.requestData = function () {
-            OctoPrint.plugins.meatpack.get().done(self.fromResponse)
         };
 
-        self.fromResponse = function(response){
-            self.totalBytes = response.transmissionStats.totalBytes;
-            self.totalBytesSec = response.transmissionStats.totalBytesSec;
-            self.packedBytes = response.transmissionStats.packedBytes;
-
-            // self.transmissionStats(response);
-            self.dataReceived = true;
+        // Get all statsa data
+        self.getAllData = function () {
+            // Don't poll api if we don't need it
+            if (self.showStatsInUI()){
+                OctoPrint.plugins.meatpack.get().done(function(response){
+                    self.totalBytes = response.transmissionStats.totalBytes;
+                    self.totalBytesSec = response.transmissionStats.totalBytesSec;
+                    self.packedBytes = response.transmissionStats.packedBytes;
+                    // self.transmissionStats(response);
+                    self.dataReceived = true;
+                    // Update UI
+                    self.updateAllText();
+                });
+            }
         };
 
+        // String formatting for variables - START
         // Thanks @FormerLurker - github
         var byte = 1024;
         self.toFileSizeString = function (bytes, precision) {
@@ -89,7 +103,7 @@ $(function() {
                 return self.toFileSizeString(self.totalBytes, 3);
             }
             else{
-                return "No Data";
+                return txt_no_data;
             }
         };
 
@@ -98,18 +112,16 @@ $(function() {
                 return self.toFileSizeString(self.packedBytes, 3);
             }
             else{
-                return "No Data";
+                return txt_no_data;
             }
         };
 
         self.txRatioString = function() {
-
             if (self.dataReceived && self.totalBytes > 0.0){
                 var ratio = self.packedBytes / self.totalBytes;
                 return ratio.toFixed(3);
-            }
-            else{
-                return "No Data";
+            }else{
+                return txt_no_data;
             }
         };
 
@@ -118,91 +130,108 @@ $(function() {
                 return self.toFileSizeString(Math.round(self.totalBytesSec), 3) + "/sec";
             }
             else{
-                return "No Data";
+                return txt_no_data;
             }
         };
 
-         self.enabledString = ko.pureComputed(function() {
+        self.enabledString = function() {
             if (self.packingEnabled()){
-                return "Enabled";
+                return txt_lbl_enabled;
             }
             else{
-                return "Disabled";
+                return txt_lbl_disabled;
             }
-        });
+        };
 
-        self.onStartup = self.onUserLoggedIn = function () {
-            self.requestData();
-            self.updateAllText();
+        // String formatting for variables - END
+
+        // On user login redraw data
+        self.onUserLoggedIn = function () {
+            self.getAllData();
         };
 
         self.onDataUpdaterPluginMessage = function (plugin, data) {
             if (plugin != "meatpack"){
                 return;
             }
-
-            self.requestData();
-            self.updateAllText();
+            self.getAllData();
         };
 
+        // Update the UI
         self.updateAllText = function () {
+            if (!self.showStatsInUI()){
+                return false;
+            }
             if (self.showTXStats()){
-                document.getElementById("meatpack_packed_tx_string").innerHTML =
-                "<span title='" +
-                text_packed + "'>" + name_packed + "</span>: <strong>" + self.txPackedString() + "</strong></div>";
-
-                document.getElementById("meatpack_total_tx_string").innerHTML =
-                "<span title='" +
-                text_total + "'>" + name_total + "</span>: <strong>" + self.txTotalString() + "</strong></div>";
-
-                document.getElementById("meatpack_ratio_string").innerHTML =
-                "<span title='" +
-                text_ratio + "'>" + name_ratio + "</span>: <strong>" + self.txRatioString() + "</strong></div>";
-
-                document.getElementById("meatpack_rate_string").innerHTML =
-                "<span title='" +
-                text_txrate + "'>" + name_txrate + "</span>: <strong>" + self.txRateString() + "</strong></div>";
+                $("#meatpack_packed_tx_string strong").html(self.txPackedString());
+                $("#meatpack_total_tx_string strong").html(self.txTotalString());
+                $("#meatpack_ratio_string strong").html(self.txRatioString());
+                $("#meatpack_rate_string strong").html(self.txRateString());
+                $("#meatpack_enabled_string strong").html(self.enabledString());
+            }else{
+                // Mimick the standard state look/feel
+                $("#meatpack_total_content div strong, #meatpack_widget_container div strong").html('-')
+                $("#meatpack_enabled_string strong").html(self.enabledString());
             }
         };
 
+        self.drawContainer = function(){
+            // Delete everyhing
+            if (!self.showStatsInUI()){
+                $('#meatpack_total_content').remove();
+                $('#meatpack_widget').remove();
+                return;
+            }
+            if (self.windowType() == "standalone"){
+                $('#meatpack_total_content').remove();
+                if ($('#meatpack_widget').length == 1){
+                    return;
+                }
+                $('<div id="meatpack_widget" class="accordion-group">\
+                    <div class="accordion-heading"><a class="accordion-toggle" data-toggle="collapse" data-target="#meatpack_widget_container"><i class="fas fa-compress icon-black"></i> '+ containerTitle +'</a></div>\
+                    <div id="meatpack_widget_container" class="accordion-body in collapse">\
+                        <div class="accordion-inner">\
+                            <div id="meatpack_packed_tx_string"><span title="'+text_packed + '">' + name_packed + '</span>: <strong></strong></div>\
+                            <div id="meatpack_total_tx_string"><span title="'+text_total + '">' + name_total + '</span>: <strong></strong></div>\
+                            <div id="meatpack_ratio_string"><span title="'+text_ratio + '">' + name_ratio + '</span>: <strong></strong></div>\
+                            <div id="meatpack_rate_string"><span title="'+text_txrate + '">' + name_txrate + '</span>: <strong></strong></div>\
+                            <div id="meatpack_enabled_string"><span title="'+text_enabled + '">' + name_enabled + '</span>: <strong></strong></div>\
+                        </div>\
+                    </div>\
+                </div>').insertAfter( "#state_wrapper" );
+                return;
+            }
+            $('#meatpack_widget').remove();
+            // Normal inside state panel
+            if ($('#meatpack_total_content').length == 1){
+                return;
+            }
+            var element = $("#state hr:eq(1)")
+            if (element.length) {
+                element.after('<section id="meatpack_total_content">\
+                    <strong>'+containerTitle+'</strong>\
+                    <div id="meatpack_packed_tx_string"><span title="'+text_packed + '">' + name_packed + '</span>: <strong></strong></div>\
+                    <div id="meatpack_total_tx_string"><span title="'+text_total + '">' + name_total + '</span>: <strong></strong></div>\
+                    <div id="meatpack_ratio_string"><span title="'+text_ratio + '">' + name_ratio + '</span>: <strong></strong></div>\
+                    <div id="meatpack_rate_string"><span title="'+text_txrate + '">' + name_txrate + '</span>: <strong></strong></div>\
+                    <div id="meatpack_enabled_string"><span title="'+text_enabled + '">' + name_enabled + '</span>: <strong></strong></div>\
+                    <hr/>\
+                </section>');
+            }
+        }
+
+        // Refresh on save
+        self.onSettingsHidden = function () {
+            self.drawContainer();
+        };
 
         self.onBeforeBinding = function() {
-            var element = $("#state").find("hr:nth-of-type(2)");
-            if (element.length) {
-                element.after(
-                "<section id='meatpack_total_content' data-bind='visible: allVisible()'>" +
-                "<strong>TX Statistics</strong>"+
-                "<div id='meatpack_packed_tx_string' data-bind='visible: showTXStats()'><span title='" +
-                text_packed + "'>" + name_packed + "</span>: No Data</div>" +
-
-                "<div id='meatpack_total_tx_string' data-bind='visible: showTXStats()'><span title='" +
-                text_total + "'>" + name_total + "</span>: No Data</strong></div>" +
-
-                "<div id='meatpack_ratio_string' data-bind='visible: showTXStats()'><span title='" +
-                text_ratio + "'>" + name_ratio + "</span>: No Data</div>" +
-
-                "<div id='meatpack_rate_string' data-bind='visible: showTXStats()'><span title='" +
-                text_txrate + "'>" + name_txrate + "</span>: No Data</div>" +
-
-                "<div id='meatpack_enabled_string' data-bind='visible: showTXStats()'><span title='" +
-                text_enabled + "'>" + name_enabled +
-                "</span>: <strong data-bind='text: enabledString'></strong></div>" +
-                 "<hr >" +
-                "</section>"
-                );
-            }
+            self.drawContainer();
         };
     }
 
     OCTOPRINT_VIEWMODELS.push({
         construct: MeatPackViewModel,
-        dependencies: ["printerStateViewModel", "settingsViewModel", "connectionViewModel"],
-        elements: [
-        "#meatpack_total_content",
-        "#meatpack_total_tx_string",
-        "#meatpack_packed_tx_string",
-        "#meatpack_ratio_string",
-        "#meatpack_rate_string",
-        "#meatpack_enabled_string"]
+        dependencies: ["settingsViewModel", "connectionViewModel"],
     });
 });

--- a/OctoPrint_MeatPack/static/js/meatpack.js
+++ b/OctoPrint_MeatPack/static/js/meatpack.js
@@ -34,7 +34,7 @@ $(function() {
         var txt_no_data = gettext("No data");
 
         var txt_lbl_disabled = gettext("Disabled");
-        var txt_lbl_enabled = gettext("Disabled");
+        var txt_lbl_enabled = gettext("Enabled");
 
         self.transmissionStats = ko.observableArray([]);
         self.dataReceived = false;

--- a/OctoPrint_MeatPack/templates/meatpack_settings.jinja2
+++ b/OctoPrint_MeatPack/templates/meatpack_settings.jinja2
@@ -19,8 +19,14 @@
             <div class="controls">
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: settings.plugins.meatpack.logTransmissionStats">
-                    Show Transmission Statistics
+                    Show Transmission Statistics&hellip;
                 </label>
+            </div>
+            <div class="controls" data-bind="visible:settings.plugins.meatpack.logTransmissionStats">
+                in <select data-bind="value: settings.plugins.meatpack.logTransmissionStatsType">
+                    <option value="state">Inside State panel</option>
+                    <option value="standalone">Standalone panel</option>
+                </select>
             </div>
         </div>
     </fieldset>


### PR DESCRIPTION
Fixed the js console bug: Javascript/console errors #21
Added an option to move meatpack stats into its own panel (Move MeatPack stats into a sidebar tab #15)
Did a bit of improvements on the locale strings.
Removed unused viewmodels and overloading of knockout - now more vanilla js (ahh jquery) updating.